### PR TITLE
Add multi-release optimised methods for LogUtils

### DIFF
--- a/log-utils/build.gradle
+++ b/log-utils/build.gradle
@@ -14,9 +14,22 @@ version = gitversion.tagOffset
 
 println "Version: $version"
 
+final java11 = sourceSets.create('java11')
+
 java {
     toolchain.languageVersion = JavaLanguageVersion.of 8
     withSourcesJar()
+
+    registerFeature(java11.name) {
+        usingSourceSet java11
+        capability project.group.toString(), project.name, project.version.toString()
+        disablePublication()
+    }
+}
+
+configurations {
+    named(java11.implementationConfigurationName) { extendsFrom implementation }
+    named(java11.compileOnlyConfigurationName) { extendsFrom compileOnly }
 }
 
 dependencies {
@@ -25,7 +38,10 @@ dependencies {
 
 tasks.named('jar', Jar) {
     manifest {
-        attributes('Automatic-Module-Name': 'net.minecraftforge.utils.logging')
+        attributes([
+                'Automatic-Module-Name': 'net.minecraftforge.utils.logging',
+                'Multi-Release'        : 'true'
+        ])
         attributes([
             'Specification-Title'   : projectDisplayName,
             'Specification-Vendor'  : projectVendor,
@@ -34,6 +50,16 @@ tasks.named('jar', Jar) {
             'Implementation-Vendor' : projectVendor,
             'Implementation-Version': project.version
         ], 'net/minecraftforge/util/logging/')
+
+        into('META-INF/versions/11') {
+            from java11.output
+        }
+    }
+}
+
+tasks.named(java11.compileJavaTaskName, JavaCompile) {
+    javaCompiler = javaToolchains.compilerFor {
+        languageVersion = JavaLanguageVersion.of 11
     }
 }
 

--- a/log-utils/src/java11/java/net/minecraftforge/util/logging/MultiReleaseMethods.java
+++ b/log-utils/src/java11/java/net/minecraftforge/util/logging/MultiReleaseMethods.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
 package net.minecraftforge.util.logging;
 
 import java.util.Map;

--- a/log-utils/src/java11/java/net/minecraftforge/util/logging/MultiReleaseMethods.java
+++ b/log-utils/src/java11/java/net/minecraftforge/util/logging/MultiReleaseMethods.java
@@ -1,0 +1,20 @@
+package net.minecraftforge.util.logging;
+
+import java.util.Map;
+
+/**
+ * Utility class for methods that are exclusively used in multi-release form. (Java 11+)
+ */
+final class MultiReleaseMethods {
+    static final String INDENT_STRING = "  ";
+
+    static <K, V> Map.Entry<K, V> mapEntry(K key, V value) {
+        return Map.entry(key, value);
+    }
+
+    static String getIndentation(byte indent) {
+        return INDENT_STRING.repeat(indent);
+    }
+
+    private MultiReleaseMethods() { }
+}

--- a/log-utils/src/main/java/net/minecraftforge/util/logging/MultiReleaseMethods.java
+++ b/log-utils/src/main/java/net/minecraftforge/util/logging/MultiReleaseMethods.java
@@ -1,0 +1,25 @@
+package net.minecraftforge.util.logging;
+
+import java.util.AbstractMap;
+import java.util.Map;
+
+/**
+ * Utility class for methods that are exclusively used in multi-release form. (Java 8)
+ */
+final class MultiReleaseMethods {
+    static final String INDENT_STRING = "  ";
+
+    static <K, V> Map.Entry<K, V> mapEntry(K key, V value) {
+        return new AbstractMap.SimpleImmutableEntry<>(key, value);
+    }
+
+    static String getIndentation(byte indent) {
+        StringBuilder builder = new StringBuilder(INDENT_STRING.length() * indent);
+        for (int i = 0; i < indent; i++) {
+            builder.append(INDENT_STRING);
+        }
+        return builder.toString();
+    }
+
+    private MultiReleaseMethods() { }
+}

--- a/log-utils/src/main/java/net/minecraftforge/util/logging/MultiReleaseMethods.java
+++ b/log-utils/src/main/java/net/minecraftforge/util/logging/MultiReleaseMethods.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
 package net.minecraftforge.util.logging;
 
 import java.util.AbstractMap;


### PR DESCRIPTION
Adds multi-release support for LogUtils to use a couple of more optimised methods that aren't available in Java 8.

__String#repeat(int)__
Should hopefully be self-explanatory... it's a more optimised variant of the StringBuilder approach that takes advantage of internal fields and methods inside the String class.

__Map#entry(K, V):__
Previously, a CapturedMessage POJO was used. This works fine and is straightforward, but its final fields are not trusted and can't be treated as a Valhalla value class in the future.

By switching to Map.Entry, we can use `new AbstractMap.SimpleImmutableEntry<>(key, value)` on Java 8 which gives us the benefit of trusted final fields (due to its final fields being defined inside JDK internals). On Java 11, we can use `Map.entry(key, value)` which additionally has the benefit of being marked with `@jdk.internal.ValueBased`, meaning we get the benefits of Valhalla value classes when running on a capable JVM.